### PR TITLE
22,25: Add JSON string escaping; Fix std::pair<> issues; Add std::tup…

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,4 +1,13 @@
 # **`fmtster` Change List**
+## **0.3.0**
+* Fixed issues with `std::pair<>`
+* Added support for `std::tuple<>` (currently only meant to hold `std::pair<>`s
+  with the first elements being `std::string`s; the second elements can differ,
+  providing heterogeneous object support)
+* Added JSON string escaping
+* Added support for JSON style setting (second format field) of 1 (in addition
+  to 0) to remove surrounding brackets/brackets
+* Added example-json.cpp
 ## **0.2.0**
 * Added support for `std::pair<>`
 * *Known issues*

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,21 @@ CXX=g++
 LD=ld
 CFLAGS=-std=c++17
 LFLAGS=
-LIBS=-lgtest -lgtest_main -lpthread -lfmt
+LIBS=-lpthread -lfmt
+TESTLIBS=-lgtest -lgtest_main
 
-all: fmtstertest
+all: fmtstertest example-json
 
 fmtstertest.o: fmtstertest.cpp fmtster.h Makefile
 	$(CXX) $(CFLAGS) -c $< -o $@
 
 fmtstertest: fmtstertest.o
-	$(CXX) $(CFLAGS) $^ -o $@ $(LFLAGS) $(LIBS)
+	$(CXX) $(CFLAGS) $^ -o $@ $(LFLAGS) $(LIBS) $(TESTLIBS)
 	strip $@
 
+example-json.o: example-json.cpp fmtster.h Makefile
+	$(CXX) $(CFLAGS) -c $< -o $@
+
+example-json: example-json.o
+	$(CXX) $(CFLAGS) $^ -o $@ $(LFLAGS) $(LIBS)
+	strip $@

--- a/README.md
+++ b/README.md
@@ -21,14 +21,18 @@
 -->
 
 # **fmtster**
+
+## **Introduction**
+
 **`fmtster`** (format-ster) is designed to work with the
 [{fmt}](https://fmt.dev/latest/index.html) library. It provides
 `fmt::formatter` templates that allow
-[`std` C++ containers](https://en.cppreference.com/w/cpp/container) to be passed
-to the `fmt::format()` family of commands, and result in a `std::string`
-serialization of the contents.
+[`std` C++ containers](https://en.cppreference.com/w/cpp/container), including
+compound containers (containers within containers) to be passed to the
+`fmt::format()` family of commands, and result in a `std::string` serialization
+of the contents.
 
-An example of its use:
+The simplest example of its use:
 > ```
 > std::map<std::string, std::map<std::string, std::vector<std::string> > > mydata;
 > ...
@@ -57,83 +61,96 @@ and its (default) output:
 > }
 > ```
 
-`fmtster` is obviously useful for serialization, but it is also a useful
-debugging aid, allowing quick dumping of `std` C++ containers to a `std::string`
-for logging during development.<br>
 <br>
-***(In the future, it is intended that `fmtster` will be modfied to work with the
-C++20 `std::format` feature.)***
+
+***(Coming soon (hopefully), `fmtster` will be modfied to work with the C++20
+`std::format` feature.)***
+
+---
+
+## **Uses**
+
+Obviously `fmtster` is useful for **serialization**, but it is also useful for
+formatting a **debug log**, allowing quick dumping of `std` C++ containers
+during development.<br>
 
 ---
 <br>
 
-## **Options**
-In keeping with the design of {fmt}, `fmtster` provides the user optional style
-configuration specifiers. However, please note that the style format for
-`fmtster` differs from the {fmt} design, because the options being controlled
-are appropriate to container serialization. *Individual type formatting is not
-currently supported.*
+## **Formatting Options**
+As with {fmt}, `fmtster` provides the user optional formatting configuration
+settings. However, please note that the settings for `fmtster` differ from
+the {fmt} design, because the options being controlled are appropriate for
+container serialization.
+
+***NOTE**: Integral type formatting is not currently supported.*
+
+There are (currently) four parameters for setting the format style:
+* Serialization Format
+* Format Style
+* Tab Specification
+* Initial Indent
+
+All of these parameters are optional. If they are not provided, the default
+value is used. Some examples:
+> `fmt::format("{}", container);`<br>
+> The default values are used for all parameters.
+
+> `fmt::format("{:,1}", container);`<br>
+> The default values are used for all parameters except the second, which
+> is set to 1.
+
+> `fmt::format("{:,,4}", container);`<br>
+> The default values are used for all parameters except the third, which
+> is set to 4.
+
+> `fmt::format("{:,,,1}", container);`<br>
+> The default values are used for all parameters except the fourth, which
+> is set to 1.
+
+> `fmt::format("{:,1,,2}, container);`<br>
+> The default values are used for all parameters except the second and
+> fourth, which are set to values of 1 and 2, respectively.
 
 <br>
 
-### Serialization Format
+---
+<br>
 
-The first style value (after the colon, before the closing brace or a comma)
-indicates the serialization format. Following this (delimited by a
-comma), zero or more style-specific specifiers can be added, themselves
-separated by commas. Optional specifiers can be left empty and the default
-values will be used. (Commas can be omitted after the last specifier provided.)
+### **Serialization Format**
 
-**EXAMPLE**:
-
-> ```
-> fmt::format("    {1}: {0:,,4,1}", myvector, "myvector")
-> ```
-> This serializes a `std::vector<>` formatted as:
-> * JSON serialization format (the first field is empty, so the default serialization format is used)
-> * default JSON style (the second field is empty, so the default JSON style is
-> used)
-> * four space tabs (overriding the default of two spaces)
-> * indented by one tab unit (four spaces; the opening bracket may not be indented, depending on the second field)
->
-> Output will look something like this:
-> ```
->     myvector: [
->         "entry1",
->         "entry2"
->     ]
-> ```
+The first value (after the colon, before the closing brace or a comma)
+indicates the serialization format.
 
 The serialization formats supported and their associated specification values
 are:
 
 * **JSON**
   * 0
-  * json *(pending)*
-  * j *(pending)*
+  * json *(possible future alias)*
+  * j *(possible future alias)*
 
 * **XML** *(pending)*
+* etc.
 
-The JSON serialization format is the default.
-
----
 <br>
 
-## **Serialization Format Details**
+The ***default*** is 0 (JSON serialization format).
+
 <br>
 
 ### **JSON**
 The JSON format as specified at http://www.json.org
 <br>
-<br>
 
-#### **JSON Options**
 The JSON format specifier includes four optional fields, including the
 serialization format specifier itself:
 
 > `{:0,<style>,<tab>,<indent>}`<br>
-> `{:json,<style>,<tab>,<indent>}` *(pending)*<br>
-> `{:j,<style>,<tab>,<indent>}` *(pending)*<br>
+> `{:json,<style>,<tab>,<indent>}` *(possible future alias)*<br>
+> `{:j,<style>,<tab>,<indent>}` *(possible future alias)*<br>
+
+<br>
 
 **Style**
 
@@ -142,37 +159,39 @@ settings for multiple characteristics of the JSON output.<br>
 <br>
 The serialization format style allows user choices for things like the position
 of opening and closing braces and brackets, the spacing between punctuation and
-values, as well as exceptional choices like grouping short arrays on one line or
-placing single entry JSON object on one line, etc.<br>
-<br>
+values, as well as exceptional choices like grouping short or empty arrays on
+one line or placing single entry JSON objects on a single line, etc.<br>
 <br>
 **NOTE: The method of specifying the serialization format style is under
-consideration:**
+consideration.**
+<br>
 
-Some proposed methods for how this field might be specified are:
+At present, there is only one JSON style option supported. A value of 0 (the
+default) will cause the output to use the default layout (see examples), with
+braces or brackets (as appropriate for JSON) around the object. A value of 1
+will remove the brackets/braces. The initiial indent (see below) is used for
+the closing brace/bracket with a setting of 0 and is used for the data if set
+to 1. (The opening brace is not currently indented.)
 
->```
-> Bitfields:   {:0,6,<tab>,<indent>}
-> Tags:        {:j,spc-after-lead-brac|one-line-one-element-array,<tab>,<indent>}
-> Struct ptr:  {:0,0x123456789ABCDEF0,<tab>,<indent>}
-> ```
 <br>
 
 **Tab**
 
 The third field indicates the type and length of the tabs:
 
-* Positive values indicate the number of spaces per tab (e.g. 4 indicates a tab consisting of 4 spaces)
-* Negative values indicate the number of tab characters per tab (e.g. -2 indictes a tab consisting of 2 hard tab ('\t') chracters)
+* Positive values indicate the number of spaces per tab (e.g. 4 indicates a tab
+  consisting of 4 spaces)
+* Negative values indicate the number of tab characters per tab (e.g. -2
+  indictes a tab consisting of 2 hard tab ('\t') chracters)
 * 0 indicates no tabs
 
 <br>
 
 **Indent**
 
-The fourth field indicates the number of tab units used on all output lines.
-This is added to the tab used internally for formatting the serialization, so
-that the entire output is indented together.
+The fourth field indicates the starting number of tab units. This is added to
+the tab used internally for formatting the serialization, so that the entire
+output is indented together.
 
 **NOTE**: The indent specifier may be ignored when outputting the first line of
 a given container. This is due to the need to differentiate between tab levels
@@ -199,3 +218,11 @@ specification to override the default settings seems like a worthwhile addition.
 However, consideration of the side-effects, such as use of `fmtster` by multiple
 modules in the same process, will necessitate more consideration of an exact
 approach.*
+
+---
+<br>
+
+## **Examples**
+<br>
+
+See `example-json.cpp` for quick start to using `fmtster`.

--- a/example-json.cpp
+++ b/example-json.cpp
@@ -1,0 +1,173 @@
+/* Copyright (c) 2021 Harman International Industries, Incorporated.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <chrono>
+using ex_clock_t = std::chrono::system_clock;
+using ex_time_point_t = std::chrono::time_point<ex_clock_t>;
+#include <iomanip>
+#include <iostream>
+using std::cout;
+using std::endl;
+#include <map>
+using std::map;
+#include <sstream>
+using std::stringstream;
+#include <string>
+using std::string;
+using namespace std::string_literals;
+#include <tuple>
+#include <utility>
+#include <variant>
+using std::variant;
+#include <vector>
+using std::vector;
+
+#include "fmtster.h"
+using fmtster::F;
+
+
+template<typename T1, typename T2>
+constexpr auto mp(T1 f, T2 s)
+{
+    return std::make_pair(f, s);
+};
+
+template<typename ...Ts>
+constexpr auto mt(Ts... es)
+{
+    return std::make_tuple(es...);
+}
+
+struct Person
+{
+    string name;
+    ex_time_point_t birthdate;
+    float salary;
+    vector<string> phones;
+    map<string, string> family;
+};
+
+
+
+template<>
+struct fmt::formatter<Person> : fmtster::FmtsterBase
+{
+    template<typename FormatContext>
+    auto format(const Person& p, FormatContext& ctx)
+    {
+        // this could use the tuple approach shown for the opt example in
+        //  main(), but this to illustrates use of the fmt::format_to() call
+        //  and care that needs to be taken with JSON commas
+
+        auto itOut = (mStyleSetting & 1) ?
+                     ctx.out() :
+                     fmt::format_to(ctx.out(), "{{\n");
+
+        const string FMTSTR_NOCOMMA = F("{{:{},{},{},{}}}",
+                                        mFormatSetting,
+                                        mStyleSetting | 1,
+                                        mTabSetting,
+                                        mDataIndentSetting);
+        const string FMTSTR = FMTSTR_NOCOMMA + ",\n";
+        itOut = format_to(itOut, FMTSTR, mp("name"s, p.name));
+
+        // @@@ TODO: Wrap this section for use with C++20
+        stringstream ss;
+        auto t = ex_clock_t::to_time_t(p.birthdate);
+        auto tm = *std::localtime(&t);
+        ss << std::put_time(&tm, "%x");
+        itOut = format_to(itOut, FMTSTR, mp("birthdate"s, ss.str()));
+
+        itOut = format_to(itOut, FMTSTR, mp("salary"s, p.salary));
+        itOut = format_to(itOut, FMTSTR, mp("phones"s, p.phones));
+        itOut = format_to(itOut, FMTSTR_NOCOMMA, mp("family"s, p.family));
+
+        if (!(mStyleSetting & 1))
+            itOut = fmt::format_to(itOut, "\n}}");
+
+        return itOut;
+    }
+};
+
+using Personnel = vector<Person>;
+
+Personnel GetPersonnel()
+{
+    static std::tm tm1{ 0, 0, 0,
+                        1, 1 - 1, 1970 - 1900 };
+    static std::tm tm2{ 0, 0, 0,
+                        31, 12 - 1, 1980 - 1900 };
+    return Personnel
+    {
+        {
+            .name = "John Doe",
+            .birthdate = ex_clock_t::from_time_t(::timelocal(&tm1)),
+            .salary = 60000,
+            .phones = { "1-800-555-1212", "867-5309" },
+            .family = { { "sister", "Jane Doe" },
+                        { "mother", "Janet Doe" },
+                        { "brother", "Jake Doe" },
+                        { "father", "James Doe" } }
+        }, {
+            .name = "Jane Doe",
+            .birthdate = ex_clock_t::from_time_t(::timelocal(&tm2)),
+            .salary = 60001,
+            .phones = { "1-888-555-8888", "736-5000" },
+            .family = { { "brother", "John Doe" },
+                        { "mother", "Janet Doe" },
+                        { "brother", "Jake Doe" },
+                        { "father", "James Doe" } }
+        }
+
+    };
+}
+
+int main()
+{
+    // Based on https://json.org/example.html
+    auto GlossSeeAlso = vector<string>{ "GML", "XML" };
+    auto GlossDef = mt(mp("para"s, "A meta-markup language, used to create markup languages such as DocBook."s),
+                       mp("GlossSeeAlso"s, GlossSeeAlso));
+    auto GlossEntry = mt(mp("ID"s, "SGML"s),
+                         mp("SortAs"s, "SGML"s),
+                         mp("GlossTerm"s, "Standard Generalized Markup Language"s),
+                         mp("Acronym"s, "SGML"s),
+                         mp("Abbrev"s, "ISO 8879:1986"s),
+                         mp("GlossDef"s, GlossDef),
+                         mp("GlossSee"s, "markup"s));
+    auto GlossList = mp("GlossEntry"s, GlossEntry);
+    auto GlossDiv = mt(mp("title"s, "S"s),
+                       mp("GlossList"s, GlossList));
+    auto glossary = mt(mp("title"s, "example glossary"s),
+                       mp("GlossDiv"s, GlossDiv));
+    auto obj = mt(mp("glossary"s, glossary));
+    cout << F("{}", obj) << endl;
+
+
+    cout << "\n\n" << endl;
+
+
+    string buildAJSON = "{\n";
+
+    size_t personNumber = 0;
+    for (auto person : GetPersonnel())
+        cout << F("{}:\n{:,1,,1}\n", personNumber++, person) << endl;
+}

--- a/fmtster.h
+++ b/fmtster.h
@@ -21,30 +21,28 @@
  * SOFTWARE.
  */
 
-#define FMTSTER_VERSION 000200 // 0.2.0
+#define FMTSTER_VERSION 000300 // 0.3.0
 
 #include <algorithm>
-#include <exception>
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <regex>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 namespace fmtster
 {
 using std::find;
-using std::exception;
 using std::string;
 using std::stoi;
 using std::declval;
 using std::void_t;
 using std::enable_if_t;
-using std::is_same;
-using std::integral_constant;
 using std::true_type;
 using std::false_type;
 using std::conjunction_v;
+using std::disjunction_v;
 using std::negation;
 
 // short helper alias for fmt::format() used by adding "using fmtster::F;" to
@@ -55,6 +53,8 @@ string F(std::string_view fmt, const Args&... args)
     return fmt::format(fmt, args...);
 }
 
+struct FmtsterBase; // forward declaration
+
 namespace internal
 {
 
@@ -63,83 +63,172 @@ struct fmtster_true
     : true_type
 {};
 
+//
 // macro to create has_FN<> templates (also creates has_FN_v<> helper)
-#define fmtster_MAKEHASFN(FN)                                               \
-template<typename T, typename... Args>                                      \
-static auto test_ ## FN(int)                                                \
-    -> fmtster_true<decltype(declval<T>().FN(declval<Args>()...))>;         \
-                                                                            \
-template<typename, typename...>                                             \
-static auto test_ ## FN(long) -> false_type;                                \
-                                                                            \
-template<typename T, typename... Args>                                      \
-struct has_ ## FN : decltype(test_ ## FN<T, Args...>(0))                    \
-{};                                                                         \
-                                                                            \
-template<typename ...Ts>                                                    \
+//
+#define fmtster_MAKEHASFN(FN)                                                  \
+template<typename T, typename... Args>                                         \
+static auto test_ ## FN(int)                                                   \
+    -> fmtster_true<decltype(declval<T>().FN(declval<Args>()...))>;            \
+                                                                               \
+template<typename, typename...>                                                \
+static auto test_ ## FN(long) -> false_type;                                   \
+                                                                               \
+template<typename T, typename... Args>                                         \
+struct has_ ## FN : decltype(test_ ## FN<T, Args...>(0))                       \
+{};                                                                            \
+                                                                               \
+template<typename ...Ts>                                                       \
 inline constexpr bool has_ ## FN ## _v = has_ ## FN<Ts...>::value
 
+//
 // macro to create has_TYPE<> templates (also creates has_TYPE_v<> helper)
-#define fmtster_MAKEHASTYPE(TYPE)                                           \
-template<typename T, typename = void>                                       \
-struct has_ ## TYPE                                                         \
-    : false_type                                                            \
-{};                                                                         \
-                                                                            \
-template<typename T>                                                        \
-struct has_ ## TYPE<T, void_t<typename T::TYPE> >                           \
-    : true_type                                                             \
-{};                                                                         \
-                                                                            \
-template<typename ...Ts>                                                    \
+//
+#define fmtster_MAKEHASTYPE(TYPE)                                              \
+template<typename T, typename = void>                                          \
+struct has_ ## TYPE                                                            \
+    : false_type                                                               \
+{};                                                                            \
+                                                                               \
+template<typename T>                                                           \
+struct has_ ## TYPE<T, void_t<typename T::TYPE> >                              \
+    : true_type                                                                \
+{};                                                                            \
+                                                                               \
+template<typename ...Ts>                                                       \
 inline constexpr bool has_ ## TYPE ## _v = has_ ## TYPE<Ts...>::value
 
+//
 // macro to create is_ID<> templates (also creates is_ID_v<> helper)
 //   COND provides the conditional value used to check traits
-#define fmtster_MAKEIS(ID, COND)                                            \
-template<typename T, typename = void>                                       \
-struct is_ ## ID                                                            \
-    : false_type                                                            \
-{};                                                                         \
-                                                                            \
-template<typename T>                                                        \
-struct is_ ## ID<T, enable_if_t<COND> >                                     \
-    : true_type                                                             \
-{};                                                                         \
-                                                                            \
-template<typename ...Ts>                                                    \
+//
+// NOTE 1: Any spaces in the CONDition argument are misinterpreted by the
+//         macro parser, so use of parentheses around this argument is
+//         recommended.
+// NOTE 2: CONDition _can_ be a logical grouping of xxx_v<> values, but it
+//         appears that all of these are evaluated, making some combinations
+//         fail before the SFINAE can kick in. std::conjunction_v<> &
+//         std::disjunction_v<> seem to use lazy evaluation, so use of them
+//         is preferred.
+#define fmtster_MAKEIS(ID, COND)                                               \
+template<typename T, typename = void>                                          \
+struct is_ ## ID                                                               \
+    : false_type                                                               \
+{};                                                                            \
+                                                                               \
+template<typename T>                                                           \
+struct is_ ## ID<T, enable_if_t<COND> >                                        \
+    : true_type                                                                \
+{};                                                                            \
+                                                                               \
+template<typename ...Ts>                                                       \
 inline constexpr bool is_ ## ID ## _v = is_ ## ID<Ts...>::value
 
+//
 // has_TYPE<> declarations
+//
 fmtster_MAKEHASTYPE(const_iterator);
 fmtster_MAKEHASTYPE(key_type);
 fmtster_MAKEHASTYPE(mapped_type);
 fmtster_MAKEHASTYPE(container_type);
 
+//
 // has_FN<> declarations
+//
 fmtster_MAKEHASFN(begin);
 fmtster_MAKEHASFN(end);
 fmtster_MAKEHASFN(at);
+
 // functional equivalent for fmtster_MAKEHASFN(operator[])
 template<typename T, typename U = void>
 struct has_operator_index
     : false_type
 {};
 template<typename T>
-struct has_operator_index<T, void_t<decltype(declval<T&>()[declval<const typename T::key_type&>()])> >
+struct has_operator_index<
+    T,
+    void_t<decltype(declval<T&>()[declval<const typename T::key_type&>()])> >
     : true_type
 {};
 
+//
 // is_ID<> declarations
-fmtster_MAKEIS(container, (conjunction_v<has_const_iterator<T>, has_begin<T>, has_end<T> >));
-// specialization for std::string, which is not considered a container by fmtster
+//
+template<template<typename...> class T, typename U>
+struct is_specialization_of : false_type
+{};
+template<template<typename...> class T, typename... Ts>
+struct is_specialization_of<T, T<Ts...>> : true_type
+{};
+template<template<typename...> class T, typename... Ts>
+inline constexpr bool is_specialization_of_v =
+    is_specialization_of<T, T<Ts...> >::value;
+
+// @@@ TODO: Determine why is_string<> equivalent using is_specialization<> doesn't work
+template<typename T>
+inline constexpr bool is_string_v = is_specialization_of_v<std::basic_string, T>;
+
+fmtster_MAKEIS(container,
+               (conjunction_v<has_const_iterator<T>, has_begin<T>, has_end<T> >));
+// overriding specialization for std::string, which is not considered a container by fmtster
 template<>
 struct is_container<string>
     : false_type
 {};
-fmtster_MAKEIS(mappish, (conjunction_v<has_key_type<T>, has_mapped_type<T>, has_operator_index<T> >));
-fmtster_MAKEIS(multimappish, (conjunction_v<has_key_type<T>, has_mapped_type<T>, negation<has_at<T, typename T::key_type> > >));
+
+fmtster_MAKEIS(mappish, (conjunction_v<has_key_type<T>,
+                                       has_mapped_type<T>,
+                                       has_operator_index<T> >));
+fmtster_MAKEIS(multimappish,
+               (conjunction_v<has_key_type<T>,
+                              has_mapped_type<T>,
+                              negation<has_at<T, typename T::key_type> > >));
 fmtster_MAKEIS(adapter, has_container_type_v<T>);
+
+// specific detection for std::pair<> only
+template<typename T>
+struct is_pair : false_type
+{};
+template<typename T1, typename T2>
+struct is_pair<std::pair<T1, T2> > : true_type
+{};
+template<typename ...Ts>
+inline constexpr bool is_pair_v = is_pair<Ts...>::value;
+
+// specific detection for std::tuple<>
+template<typename T>
+struct is_tuple : false_type
+{};
+template<typename... Ts>
+struct is_tuple<std::tuple<Ts...> > : true_type
+{};
+template<typename... Ts>
+inline constexpr bool is_tuple_v = is_tuple<Ts...>::value;
+
+// tools for use below
+fmtster_MAKEIS(fmtsterable,
+               (std::is_base_of_v<fmtster::FmtsterBase, fmt::formatter<T> >));
+fmtster_MAKEIS(braceable, (disjunction_v<is_mappish<T>,
+                                         is_multimappish<T>,
+                                         is_pair<T>,
+                                         is_tuple<T> >));
+
+//
+// misc helpers
+//
+// template argument iteration for std::tuple<>
+template<typename F, typename... Ts, std::size_t... Is>
+void ForEachElement(const std::tuple<Ts...>& tup,
+                    F fn,
+                    std::index_sequence<Is...>)
+{
+    (void)(int[]) { 0, ((void)fn(std::get<Is>(tup)), 0)... };
+}
+template<typename F, typename...Ts>
+void ForEachElement(const std::tuple<Ts...>& tup, F fn)
+{
+    ForEachElement(tup, fn, std::make_index_sequence<sizeof...(Ts)>());
+}
 
 } // namespace internal
 
@@ -147,17 +236,62 @@ fmtster_MAKEIS(adapter, has_container_type_v<T>);
 struct FmtsterBase
 {
     int mFormatSetting = 0;     // format (0 = JSON)
-    int mStyleSetting = 0;      // style (0 = default)
-    int mTabSetting = 2;        // tab (0 = none, >0 = # of spaces, |<0| = # of tabs)
-    int mIndentSetting = 0;     // beginning number of indents
-    string mTab;                // expanded tab
-    string mIndent;             // expanded indent
+    int mStyleSetting = 0;      // style (0 = default, 1 = no brackets/braces)
+    int mTabSetting = 2;        // tab (0: none, >0: # of spaces, |<0|: # of tabs)
+    int mBraIndentSetting = 0;  // beginning number of brace/bracket indents
+    int mDataIndentSetting = 1; // beginning number of data indents
 
-    // Parses the format choice argument id in the format {<format>,<style>,<tab>,<indent>}.
+    string mTab;                // expanded tab
+    string mBraIndent;          // expanded brace/bracket indent
+    string mDataIndent;         // expanded data indent
+
+    template<typename T>
+    T escapeValue(const T& val)
+    {
+        return val;
+    }
+    // escape string the JSON way
+    string escapeValue(const string& str)
+    {
+        string out;
+        out.reserve(str.length() * 6);
+        for (const char c : str)
+        {
+            if ((c <= '\x1F') || (c >= '\x7F'))
+            {
+                switch (c)
+                {
+                case '\b': out += R"(\b)"; break;
+                case '\f': out += R"(\f)"; break;
+                case '\n': out += R"(\n)"; break;
+                case '\r': out += R"(\r)"; break;
+                case '\t': out += R"(\t)"; break;
+                default:
+                    out += F(R"(\u{:04X})", (unsigned int)((unsigned char)c));
+                }
+            }
+            else
+            {
+                switch (c)
+                {
+                case '\\':   out += R"(\\)"; break;
+                case '\"':   out += R"(\")"; break;
+                case '/':    out += R"(\/)"; break;
+                case '\x7F': out += R"(\u007F)"; break;
+                default:     out += c;
+                }
+            }
+        }
+
+        return out;
+    } // escapeValue()
+
+    // Parses the format in the format {<format>,<style>,<tab>,<indent>}.
     // > format (default is 0: JSON):
     //     0 = JSON
     // >     style (default is 0):
-    //         0 = Google (https://google.github.io/styleguide/jsoncstyleguide.xml)
+    //         0 = open brace/bracket on same line as key, each property on new line
+    //         1 = same as 0 with no open/close braces/brackets
     // > tab (default is 2 spaces):
     //     positive integers: spaces
     //     0: no tab
@@ -181,15 +315,18 @@ struct FmtsterBase
         {
             mFormatSetting = stoi(smFormat);
             if (mFormatSetting != 0)
-                throw fmt::format_error(F("unsupported output format: \"{}\"", smFormat));
+                throw fmt::format_error(fmt::format("unsupported output format: \"{}\"",
+                                                    smFormat));
         }
 
         auto smStyle = sm[2].str();
         if (!smStyle.empty())
         {
             mStyleSetting = stoi(smStyle);
-            if (mStyleSetting != 0)
-                throw fmt::format_error(F("invalid style (\"{}\") for format \"{}\"", mStyleSetting, mFormatSetting));
+            if ((mStyleSetting != 0) && (mStyleSetting != 1))
+                throw fmt::format_error(fmt::format("invalid style (\"{}\") for format \"{}\"",
+                                                    mStyleSetting,
+                                                    mFormatSetting));
         }
 
         auto smTab = sm[3].str();
@@ -201,155 +338,177 @@ struct FmtsterBase
         auto smIndent = sm[4].str();
         if (!smIndent.empty())
         {
-            mIndentSetting = stoi(smIndent);
-            if (mIndentSetting < 0)
-                throw fmt::format_error(F("invalid indent: \"{}\"", mIndentSetting));
+            mBraIndentSetting = stoi(smIndent);
+            if (mBraIndentSetting < 0)
+                throw fmt::format_error(fmt::format("invalid indent: \"{}\"",
+                                        mBraIndentSetting));
         }
 
         mTab = (mTabSetting > 0)
                ? string(mTabSetting, ' ')
                : string(-mTabSetting, '\t');
 
-        mIndent.clear();
-        for (int i = 0; i < mIndentSetting; i++)
-            mIndent += mTab;
+        for (int i = 0; i < mBraIndentSetting; i++)
+            mBraIndent += mTab;
+
+        mDataIndentSetting = mBraIndentSetting;
+        mDataIndent = mBraIndent;
+
+        if (!(mStyleSetting & 1))
+        {
+            mDataIndentSetting++;
+            mDataIndent += mTab;
+        }
 
         return itCtxEnd;
+    } // parse()
+
+    // templated function to provide non-container {fmt} string
+    template<typename T, typename = void>
+    std::enable_if_t<std::negation_v<internal::is_fmtsterable<T> >, std::string>
+        createFormatString(const T& val,
+                           const string& indent,
+                           bool /* not used */,
+                           bool addComma)
+    {
+        return indent + (addComma ? "{}," : "{}");
     }
 
-    // non-container types
+    // templated function to provided {fmt} string and add quotes to strings
+    string createFormatString(const string& val,
+                              const string& indent,
+                              bool /* not used */,
+                              bool addComma)
+    {
+        return indent + (addComma ? "\"{}\"," : "\"{}\"");
+    }
+
     template<typename T>
-    string appendFormatString(const T&, bool addComma)
+    std::enable_if_t<internal::is_fmtsterable_v<T>, std::string>
+        createFormatString(const T&,
+                           const string&,
+                           bool addBraces,
+                           bool addComma)
     {
-        return addComma ? "{},\n" : "{}\n";
+        return fmt::format("{{:{},{},{},{}}}{}",
+                           mFormatSetting,
+                           !addBraces ? (mStyleSetting | 1) : (mStyleSetting & ~1),
+                           mTabSetting,
+                           mDataIndentSetting,
+                           addComma ? "," : "");
     }
-
-    // add quotes to strings
-    string appendFormatString(const string&, bool addComma)
-    {
-        return addComma ? "\"{}\",\n" : "\"{}\"\n";
-    }
-
-    // create format string to be used by format_to() in child class format()
-    template <typename T>
-    string appendValueFormatString(const T& val, bool addComma)
-    {
-        using fmtster::F;
-
-        if (internal::is_container<T>{})
-        {
-            return F("{{:{},{},{},{}}}{}\n",
-                     mFormatSetting,
-                     mStyleSetting,
-                     mTabSetting,
-                     mIndentSetting + 1,
-                     addComma ? "," : "");
-        }
-        else
-        {
-            return appendFormatString(val, addComma);
-        }
-    }
-};
-
-// base class for mappish containers
-template<typename T>
-struct FmtsterMapBase : FmtsterBase
-{
-    template<typename FormatContext>
-    auto format(const T& ac, FormatContext& ctx)
-    {
-        // get starting output iterator
-        auto itOut = ctx.out();
-
-        // output opening brace
-        itOut = fmt::format_to(itOut, "{{\n");
-
-        // begin constructing format string for possibly recursive F() call
-        // below, used for each entry in the map:
-        //   {indent}{tab}\"{key}\"
-        const std::string fmtPrefix("{}{}\"{}\": ");
-
-        // iterate through and output each entry
-        auto remainingElements = ac.size();
-        for (const auto [key, val] : ac)
-        {
-            std::string nextFmtStr(fmtPrefix);
-            nextFmtStr += appendValueFormatString(val, --remainingElements != 0);
-            itOut = fmt::format_to(itOut, nextFmtStr, mIndent, mTab, key, val);
-        }
-
-        // output closing brace
-        itOut = fmt::format_to(itOut, "{}}}", mIndent);
-
-        return itOut;
-    }
-};
+}; // struct FmtterBase
 
 } // namespace fmtster
 
-// single value per entry containers
+// fmt::formatter<> used for all containers
 template<typename T, typename Char>
 struct fmt::formatter<T,
                       Char,
-                      std::enable_if_t<std::conjunction_v<fmtster::internal::is_container<T>,
-                                                          std::negation<fmtster::internal::is_mappish<T> >,
-                                                          std::negation<fmtster::internal::is_multimappish<T> > > > >
+                      std::enable_if_t<fmtster::internal::is_container_v<T> > >
     : fmtster::FmtsterBase
 {
     template<typename FormatContext>
+    using FCIt_t = decltype(std::declval<FormatContext>().out());
+
+    // templated function inner loop function for all containers except multimaps
+    template<typename FormatContext, typename C = T>
+    std::enable_if_t<std::negation_v<fmtster::internal::is_multimappish<C> > >
+        format_loop(const C& c, FCIt_t<FormatContext>& itOut)
+    {
+        using namespace fmtster::internal;
+
+        auto itC = c.begin();
+        while (itC != c.end())
+        {
+            std::string fmtStr;
+            if (!(mStyleSetting & 1) || (itC != c.begin()))
+                fmtStr = "\n";
+
+            const auto& val = *itC;
+
+            if (!is_braceable_v<C>)
+                fmtStr += mDataIndent;
+
+            itC++;
+
+            fmtStr += createFormatString(val, "", !is_braceable_v<C>, itC != c.end());
+
+            itOut = fmt::format_to(itOut, fmtStr, escapeValue(val));
+        }
+    }
+
+    // templated function inner loop function for multimaps
+    template<typename FormatContext, typename C = T>
+    std::enable_if_t<fmtster::internal::is_multimappish_v<C> >
+        format_loop(const C& c, FCIt_t<FormatContext>& itOut)
+    {
+        auto remainingElements = c.size();
+        if (c.empty())
+        {
+            itOut = fmt::format_to(itOut, " ");
+        }
+        else
+        {
+            auto it = c.begin();
+            while (it != c.end())
+            {
+                std::string fmtStr;
+                if ((!mStyleSetting & 1) || (it != c.begin()))
+                    fmtStr = "\n";
+
+                const auto& key = it->first;
+                fmtStr += createFormatString(key, mDataIndent, false, false);
+                fmtStr += " : ";
+                itOut = fmt::format_to(itOut, fmtStr, escapeValue(key));
+
+                std::vector<typename C::mapped_type> vals;
+                do
+                {
+                    vals.insert(vals.begin(), it->second);
+                    it++;
+                } while ((it != c.end()) && (it->first == key));
+
+                itOut = fmt::format_to(itOut,
+                                       createFormatString(vals, "", true, it != c.end()),
+                                       vals);
+            }
+        }
+    }
+
+    template<typename FormatContext>
     auto format(const T& sc, FormatContext& ctx)
     {
-        // get starting output iterator
-        auto itOut = ctx.out();
+        using namespace fmtster::internal;
 
-        // output opening bracket
-        itOut = fmt::format_to(itOut, "[\n");
+        // output opening bracket/brace (if enabled)
+        auto itOut = (mStyleSetting & 1) ?
+                     ctx.out() :
+                     fmt::format_to(ctx.out(), is_braceable_v<T> ? "{{" : "[");
 
-        // begin constructing format string for possibly recursive F() call
-        // below, used for each entry in the map:
-        //   {indent}{tab}
-        const std::string fmtPrefix("{}{}");
+        const bool empty = (sc.end() == sc.begin());
 
-        // iterate through and output each entry
-        // all this iterator fun is to detect the last entry for the comma
-        //  decision below without using sc.size(), which isn't available for
-        //  all sequential containers (.e.g forrward_list<>)
-        auto itSC = sc.begin();
-        while (itSC != sc.end())
-        {
-            auto val = *itSC;
-            itSC++;
-            std::string nextFmtStr(fmtPrefix);
-            nextFmtStr += appendValueFormatString(val, itSC != sc.end());
-            // use format above
-            itOut = fmt::format_to(itOut, nextFmtStr, mIndent, mTab, val);
-        }
+        if (empty && !(mStyleSetting & 1))
+            itOut = fmt::format_to(itOut, " ");
+        else
+            format_loop<FormatContext, T>(sc, itOut);
+
         // output closing brace
-        itOut = fmt::format_to(itOut, "{}]", mIndent);
+        if (!(mStyleSetting & 1))
+        {
+            if (empty)
+                itOut = fmt::format_to(itOut, is_braceable_v<T> ? "}}" : "]");
+            else
+                itOut = fmt::format_to(itOut,
+                                       is_braceable_v<T> ? "\n{}}}" : "\n{}]",
+                                       mBraIndent);
+        }
+
         return itOut;
     }
-};
+}; // struct fmt::formatter< containers >
 
-// unique key key/value containers
-template<typename T, typename Char>
-struct fmt::formatter<T,
-                      Char,
-                      std::enable_if_t<std::conjunction_v<fmtster::internal::is_container<T>,
-                                                          fmtster::internal::is_mappish<T> > > >
-    : fmtster::FmtsterMapBase<T>
-{};
-
-// multiple key key/value containers
-template<typename T, typename Char>
-struct fmt::formatter<T,
-                      Char,
-                      std::enable_if_t<std::conjunction_v<fmtster::internal::is_container<T>,
-                                                          fmtster::internal::is_multimappish<T> > > >
-    : fmtster::FmtsterMapBase<T>
-{};
-
-// adapters
+// fmt::formatter<> for adapters (wraps containers & removes some functions)
 template<typename A, typename Char>
 struct fmt::formatter<A,
                       Char,
@@ -360,6 +519,7 @@ struct fmt::formatter<A,
     template<typename ParseContext>
     constexpr auto parse(ParseContext& ctx)
     {
+        // get adapter format and forward to internal type
         auto itCtxEnd = std::find(ctx.begin(), ctx.end(), '}');
         mStrFmt = "{" + std::string(ctx.begin(), itCtxEnd) + "}";
         return itCtxEnd;
@@ -383,68 +543,86 @@ struct fmt::formatter<A,
     {
         return fmt::format_to(ctx.out(), mStrFmt, GetAdapterContainer(ac));
     }
-};
+}; // struct fmt::formatter< adapters >
 
-// pairs
+// fmt::formatter<> for std::pair<>
 template<typename T1, typename T2>
 struct fmt::formatter<std::pair<T1, T2> > : fmtster::FmtsterBase
 {
-    // integral types
-    template<typename T>
-    std::string formatString(const T&)
+    // create format string
+    std::string createPairFormatString(const T1& v1, const T2& v2)
     {
-        return "{}";
-    }
-
-    // add quotes to strings
-    std::string formatString(const std::string&)
-    {
-        return "\"{}\"";
-    }
-
-    // create format string to be used by format_to() in format()
-    std::string formatPairFormatString(const T1& v1, const T2& v2)
-    {
-        using fmtster::F;
-        using context = fmt::buffer_context<char>;
-
         std::string fmtStr;
-        if (std::is_base_of_v<fmtster::FmtsterBase, fmt::formatter<T1> >
-            && !std::is_same_v<std::string, T1>)
-        {
-            fmtStr = F("{{:{},{},{},{}}} : ",
-                       mFormatSetting,
-                       mStyleSetting,
-                       mTabSetting,
-                       mIndentSetting + 1);
-        }
-        else
-        {
-            fmtStr = F("{}{} : ", mIndent, formatString(v1));
-        }
 
-        if (std::is_base_of_v<fmtster::FmtsterBase, fmt::formatter<T2> >
-            && !std::is_same_v<std::string, T2>)
-        {
-            fmtStr += F("{{:{},{},{},{}}}",
-                       mFormatSetting,
-                       mStyleSetting,
-                       mTabSetting,
-                       mIndentSetting + 1);
-        }
-        else
-        {
-            fmtStr += formatString(v2);
-        }
+        if (!(mStyleSetting & 1))
+            fmtStr += "{{\n";
+
+        fmtStr += createFormatString(v1, mDataIndent, false, false);
+        fmtStr += " : ";
+        fmtStr += createFormatString(v2, "", true, false);
+
+        if (!(mStyleSetting & 1))
+            fmtStr += fmt::format("\n{}}}}}", mBraIndent);
 
         return fmtStr;
-    }
+    } // createPairFormatString()
 
     template<typename FormatContext>
     auto format(const std::pair<T1, T2>& p, FormatContext& ctx)
     {
         return format_to(ctx.out(),
-                         formatPairFormatString(p.first, p.second),
-                         p.first, p.second);
+                         createPairFormatString(p.first, p.second),
+                         escapeValue(p.first), escapeValue(p.second));
     }
-};
+}; // struct fmt::formatter<std::pair<> >
+
+// fmt::formatter<> for std::tuple<> (wraps group of heterogeneous objects known at compile time)
+template<typename... Ts>
+struct fmt::formatter<std::tuple<Ts...> > : fmtster::FmtsterBase
+{
+    template<typename FormatContext>
+    auto format(const std::tuple<Ts...>& tup, FormatContext& ctx)
+    {
+        using namespace fmtster::internal;
+
+        // output opening bracket (if enabled)
+        auto itOut = (mStyleSetting & 1) ?
+                     ctx.out() :
+                     fmt::format_to(ctx.out(), "{{");
+        auto count = sizeof...(Ts);
+
+        const bool empty = !count;
+        if (empty && !(mStyleSetting & 1))
+        {
+            itOut = fmt::format_to(itOut, " ");
+        }
+        else
+        {
+            ForEachElement(tup,
+                           [&](const auto& elem)
+                           {
+                               std::string fmtStr;
+                               if (!(mStyleSetting & 1)
+                                   || (count != sizeof...(Ts)))
+                                   fmtStr = "\n";
+
+                               fmtStr += createFormatString(elem,
+                                                            mDataIndent,
+                                                            false,
+                                                            --count);
+                               itOut = fmt::format_to(itOut, fmtStr, elem);
+                           });
+
+            // output closing brace
+            if (!(mStyleSetting & 1))
+            {
+                if (empty)
+                    itOut = fmt::format_to(itOut, "}");
+                else
+                    itOut = fmt::format_to(itOut, "\n{}}}", mBraIndent);
+            }
+        }
+
+        return itOut;
+    }
+}; // struct fmt::formatter<std::tuple<> >


### PR DESCRIPTION
* Added code to escape JSON strings
* Fixed issues with JSON support of `std::pair<>`
* Added JSON support for `std::tuple<>`
* Combined JSON code for value-only and key/value containers
* Fixed corner case issues with JSON brace/bracket indenting
* Added support for JSON setting value of 1, which disables braces/brackets
* Updated JSON tests for changes
* Added example-json.cpp
* Bumped version to 0.3.0