### PR TITLE
Add system newline support; Fix exception strings; Add benchmarking to example-json; Misc cleanup

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,4 +1,8 @@
 # **`fmtster` Change List**
+## **0.5.1**
+* Added support for system-specific newlines (can be overridden by user in
+  `fmtster::XXXStyle` structure)
+* Fixed some exception messages which were missing type information
 ## **0.5.0**
 * Reordered arguments to help minimize empty arguments (see README.md), and in
   anticipation of a future change which might eliminate the need for the fourth

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 
 CXX=g++
 LD=ld
-CFLAGS=-std=c++17 -g
+CFLAGS=-std=c++17 -g -O3
 LFLAGS=
 LIBS=-lpthread -lfmt
 TESTLIBS=-lgtest -lgtest_main
@@ -32,11 +32,11 @@ fmtstertest.o: fmtstertest.cpp fmtster.h Makefile
 
 fmtstertest: fmtstertest.o
 	$(CXX) $(CFLAGS) $^ -o $@ $(LFLAGS) $(TESTLIBS) $(LIBS)
-#	strip $@
+	strip $@
 
 example-json.o: example-json.cpp fmtster.h Makefile
 	$(CXX) $(CFLAGS) -c $< -o $@
 
 example-json: example-json.o
 	$(CXX) $(CFLAGS) $^ -o $@ $(LFLAGS) $(LIBS)
-#	strip $@
+	strip $@

--- a/example-json.cpp
+++ b/example-json.cpp
@@ -102,7 +102,7 @@ struct fmt::formatter<Person1>
 
         itFC = format_to(itFC,
                          "{:{},{},{},{}},\n",
-                         mp("name"s, p.name),
+                         mp("name", p.name),
                          mIndentSetting,
                          "-b",
                          mStyleValue,
@@ -116,21 +116,21 @@ struct fmt::formatter<Person1>
 
         itFC = format_to(itFC,
                          "{:{},{},{},{}},\n",
-                         mp("birthdate"s, ss.str()),
+                         mp("birthdate", ss.str()),
                          mIndentSetting,
                          "-b",
                          mStyleValue,
                          mFormatSetting);
         itFC = format_to(itFC,
                          "{:{},{},{},{}},\n",
-                         mp("salary"s, p.salary),
+                         mp("salary", p.salary),
                          mIndentSetting,
                          "-b",
                          mStyleValue,
                          mFormatSetting);
         itFC = format_to(itFC,
                          "{:{},{},{},{}},\n",
-                         mp("phones"s, p.phones),
+                         mp("phones", p.phones),
                          mIndentSetting,
                          "-b",
                          mStyleValue,
@@ -139,7 +139,7 @@ struct fmt::formatter<Person1>
         // Note this entry's format string does not end a comma
         itFC = format_to(itFC,
                          "{:{},{},{},{}}",
-                         mp("family"s, p.family),
+                         mp("family", p.family),
                          mIndentSetting,
                          "-b",
                          mStyleValue,
@@ -170,11 +170,11 @@ struct fmt::formatter<Person2>
         ss << std::put_time(&tm, "%x");
 
         auto tup = mt(
-            mp("name"s, p.name),
-            mp("birthdate"s, ss.str()),
-            mp("salary"s, p.salary),
-            mp("phones"s, p.phones),
-            mp("family"s, p.family)
+            mp("name", p.name),
+            mp("birthdate", ss.str()),
+            mp("salary", p.salary),
+            mp("phones", p.phones),
+            mp("family", p.family)
         );
         return format_to(ctx.out(),
                          "{:{},{},{},{}}",
@@ -239,8 +239,8 @@ struct fmt::formatter<Color>
         resolveArgs(ctx);
 
         auto tup = std::make_tuple(
-            make_pair("hue"s, color.hue),
-            make_pair("primaries"s, color.primaries)
+            make_pair("hue", color.hue),
+            make_pair("primaries", color.primaries)
         );
         return format_to(ctx.out(),
                          "{:{},{},{},{}}",
@@ -275,54 +275,63 @@ public:
 
 int main()
 {
-
-{
-map<string, bool> boolmap =
-{
-    { "true", true }, { "false", false }, { "maybe", false }
-};
-string str;
-{
-    BENCHMARK;
-    for (int i = 10 /* 0000 */; i; --i)
-        str = F("{}", boolmap);
-}
-
-fmtster::JSONStyle initialStyle;
-fmtster::JSONStyle eightCharStyle;
-eightCharStyle.tabCount = 8;
-{
-    BENCHMARK;
-    for (int i = 10 /* 0000 */; i; --i)
+    // Benchmarks
+    map<string, bool> boolmap =
     {
-        str = F("{:,,{},json}", boolmap, eightCharStyle.value);
-        str = F("{:,,{},json}", boolmap, initialStyle.value);
-    }
-}
+        { "true", true }, { "false", false }, { "maybe", false }
+    };
 
-}
+    string str;
+    {
+        BENCHMARK;
+        for (int i = 100000; i; --i)
+            str = F("{}", boolmap);
+    }
+
+    fmtster::JSONStyle initialStyle;
+    fmtster::JSONStyle eightCharStyle;
+    eightCharStyle.tabCount = 8;
+    {
+        BENCHMARK;
+        for (int i = 100000; i; --i)
+        {
+            str = F("{:,,{},json}", boolmap, eightCharStyle.value);
+            str = F("{:,,{},json}", boolmap, initialStyle.value);
+        }
+    }
+
+    fmtster::JSONStyle hardTabStyle;
+    hardTabStyle.hardTab = true;
+    {
+        BENCHMARK;
+        for (int i = 100000; i; --i)
+        {
+            str = F("{:,,{},json}", boolmap, eightCharStyle.value);
+            str = F("{:,,{},json}", boolmap, hardTabStyle.value);
+            str = F("{:,,{},json}", boolmap, initialStyle.value);
+        }
+    }
+
     // Based on https://json.org/example.html
     auto GlossSeeAlso = vector<string>{ "GML", "XML" };
-    auto GlossDef = mt(mp("para"s, "A meta-markup language, used to create markup languages such as DocBook."s),
-                       mp("GlossSeeAlso"s, GlossSeeAlso));
-    auto GlossEntry = mt(mp("ID"s, "SGML"s),
-                         mp("SortAs"s, "SGML"s),
-                         mp("GlossTerm"s, "Standard Generalized Markup Language"s),
-                         mp("Acronym"s, "SGML"s),
-                         mp("Abbrev"s, "ISO 8879:1986"s),
-                         mp("GlossDef"s, GlossDef),
-                         mp("GlossSee"s, "markup"s));
-    auto GlossList = mp("GlossEntry"s, GlossEntry);
-    auto GlossDiv = mt(mp("title"s, "S"s),
-                       mp("GlossList"s, GlossList));
-    auto glossary = mt(mp("title"s, "example glossary"s),
-                       mp("GlossDiv"s, GlossDiv));
-    auto obj = mt(mp("glossary"s, glossary));
+    auto GlossDef = mt(mp("para", "A meta-markup language, used to create markup languages such as DocBook."),
+                       mp("GlossSeeAlso", GlossSeeAlso));
+    auto GlossEntry = mt(mp("ID", "SGML"),
+                         mp("SortAs", "SGML"),
+                         mp("GlossTerm", "Standard Generalized Markup Language"),
+                         mp("Acronym", "SGML"),
+                         mp("Abbrev", "ISO 8879:1986"),
+                         mp("GlossDef", GlossDef),
+                         mp("GlossSee", "markup"));
+    auto GlossList = mp("GlossEntry", GlossEntry);
+    auto GlossDiv = mt(mp("title", "S"),
+                       mp("GlossList", GlossList));
+    auto glossary = mt(mp("title", "example glossary"),
+                       mp("GlossDiv", GlossDiv));
+    auto obj = mt(mp("glossary", glossary));
     cout << F("{}", obj) << endl;
 
-
     cout << "\n\n" << endl;
-
 
     // vector of Person1, where Person1 has a specialized fmt::formatter<>
     // based on fmtster
@@ -394,7 +403,7 @@ eightCharStyle.tabCount = 8;
 
         // "-b" disables braces around the objects
         // 2 initial indents: 1 for the brace (above) + 1 more for the data inside
-        cout << F("{:2,-b},\n", mp("name"s, std::get<0>(pr)));
+        cout << F("{:2,-b},\n", mp("name", std::get<0>(pr)));
         cout << F("{:2,-b}\n", std::get<1>(pr));
 
         // care must be taken to properly handle JSON commas

--- a/example-json.cpp
+++ b/example-json.cpp
@@ -284,7 +284,7 @@ map<string, bool> boolmap =
 string str;
 {
     BENCHMARK;
-    for (int i = 100000; i; --i)
+    for (int i = 10 /* 0000 */; i; --i)
         str = F("{}", boolmap);
 }
 
@@ -293,7 +293,7 @@ fmtster::JSONStyle eightCharStyle;
 eightCharStyle.tabCount = 8;
 {
     BENCHMARK;
-    for (int i = 100000; i; --i)
+    for (int i = 10 /* 0000 */; i; --i)
     {
         str = F("{:,,{},json}", boolmap, eightCharStyle.value);
         str = F("{:,,{},json}", boolmap, initialStyle.value);

--- a/fmtster.h
+++ b/fmtster.h
@@ -588,6 +588,7 @@ public:
     {
         if (!mLastStyleValue || (mLastStyleValue != mStyle.value))
         {
+cout << __func__ << "(): expanding" << endl;
             const JSONStyle style(mStyle.value);
             tab = style.hardTab
                   ? string(style.tabCount, '\t')

--- a/fmtster.h
+++ b/fmtster.h
@@ -21,7 +21,7 @@
  * SOFTWARE.
  */
 
-#define FMTSTER_VERSION 000500 // 0.5.0
+#define FMTSTER_VERSION 000501 // 0.5.1
 
 #include <algorithm>
 #include <cstdint>
@@ -32,11 +32,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#include <iostream>
-using std::cout;
-using std::endl;
-using std::boolalpha;
 
 namespace fmtster
 {
@@ -68,22 +63,23 @@ string F(std::string_view fmt, const Args&... args)
 //
 enum JSS
 {
-    BLANK               = 0x0,
-    reserved_1          = 0x1,
-    SPACE               = 0x2,
-    SPACEx2             = 0x3,
-    reserved_4          = 0x4,
-    reserved_5          = 0x5,
-    TAB                 = 0x6,
-    TABx2               = 0x7,
-    NEWLINE             = 0x8,
-    reserved_9          = 0x9,
-    NEWLINE_SPACE       = 0xA,
-    NEWLINE_SPACEx2     = 0xB,
-    reserved_C          = 0xC,
-    reserved_D          = 0xD,
-    NEWLINE_TAB         = 0xE,
-    NEWLINE_TABx2       = 0xF
+    // gaps                   options
+    BLANK           = 0x0,  PACKED = 0x0,
+    reserved_1      = 0x1,  SAMELINE = 0x1,
+    SPACE           = 0x2,  reserved_2 = 0x2,
+    SPACEx2         = 0x3,  SAMESTYLE = 0x3,
+    reserved_4      = 0x4,
+    reserved_5      = 0x5,
+    TAB             = 0x6,
+    TABx2           = 0x7,
+    NEWLINE         = 0x8,
+    reserved_9      = 0x9,
+    NEWLINE_SPACE   = 0xA,
+    NEWLINE_SPACEx2 = 0xB,
+    reserved_C      = 0xC,
+    reserved_D      = 0xD,
+    NEWLINE_TAB     = 0xE,
+    NEWLINE_TABx2   = 0xF
 }; // enum JSS
 
 //
@@ -118,8 +114,9 @@ enum JSS
                                                                                \
         unsigned int emptyArray : 2;                                           \
         unsigned int emptyObject : 2;                                          \
-        unsigned int sva : 2;                                                  \
-        unsigned int svo : 2;                                                  \
+                                                                               \
+        unsigned int singleLineArray : 2;                                      \
+        unsigned int singleLineObject : 2;                                     \
     }
 
 #else
@@ -127,6 +124,8 @@ enum JSS
 // @@@ TODO: See above (only these are currently implemented)
 #define JSONSTYLESTRUCT                                                        \
     {                                                                          \
+        bool cr : 1;                                                           \
+        bool lf : 1;                                                           \
         bool hardTab : 1;                                                      \
         unsigned int tabCount : 4;                                             \
     }
@@ -334,8 +333,6 @@ union ForwardJSONStyle
 constexpr internal::ForwardJSONStyle DEFAULTJSONCONFIG =
 {
     {
-#if false // @@@ disable members that are not implemented
-
 #ifdef _WIN32
         .cr = true,
         .lf = true,
@@ -346,8 +343,6 @@ constexpr internal::ForwardJSONStyle DEFAULTJSONCONFIG =
         .cr = false,
         .lf = true,
 #endif
-
-#endif // false
 
         .hardTab = false,
         .tabCount = 2,
@@ -368,8 +363,9 @@ constexpr internal::ForwardJSONStyle DEFAULTJSONCONFIG =
 
         .emptyArray = JSS::SPACE,
         .emptyObject = JSS::SPACE,
-        .sva = JSS::SAMELINE,
-        .svo = JSS::SAMELINE
+
+        .singleLineArray = JSS::SAMELINE,
+        .singleLineObject = JSS::SAMELINE
 
 #endif // false
 
@@ -408,13 +404,14 @@ struct StyleHelper
     {
         VALUE_T value;
         JSONStyle jsonStyle;    // never actually referenced
-        // XMLStyle xmlStyle;      // never actually references
+        // XMLStyle xmlStyle;      // never actually referenced
     } mStyle;
 
     //
     // Common expanded strings
     //
-    string tab;
+    string mNewline;
+    string mTab;
 
     StyleHelper(VALUE_T value)
       : mStyle{value}
@@ -515,11 +512,35 @@ struct StyleHelper
 class JSONStyleHelper
   : public StyleHelper
 {
+protected:
     VALUE_T mLastStyleValue;
 
+#if false // @@@ TODO
+
+    string mArrayGap[3];
+    string mObjectGap[7];
+    string mEmptyArray;
+    string mEmptyObject;
+
+#endif // false
+
+    string expand(unsigned int bfv)
+    {
+        using namespace std::string_literals;
+
+        string e;
+        if (bfv & 8)
+            e += mNewline;
+        if ((bfv & 3) == 3)
+            e += (bfv & 4) ? mTab + mTab : "  "s;
+        else if ((bfv & 3) == 2)
+            e += (bfv & 4) ? mTab : " "s;
+        return e;
+    } // expand()
+
 public:
-    JSONStyleHelper(VALUE_T value = DEFAULTJSONCONFIG.value)
-      : StyleHelper(value ? value : DEFAULTJSONCONFIG.value),
+    JSONStyleHelper(VALUE_T val = DEFAULTJSONCONFIG.value)
+      : StyleHelper(val ? val : DEFAULTJSONCONFIG.value),
         mLastStyleValue(0)
     {
         updateExpansions();
@@ -588,14 +609,39 @@ public:
     {
         if (!mLastStyleValue || (mLastStyleValue != mStyle.value))
         {
-cout << __func__ << "(): expanding" << endl;
             const JSONStyle style(mStyle.value);
-            tab = style.hardTab
-                  ? string(style.tabCount, '\t')
-                  : string(style.tabCount, ' ');
+
+            if (style.cr)
+                mNewline = "\r";
+            if (style.lf)
+                mNewline += "\n";
+
+            mTab = style.hardTab
+                   ? string(style.tabCount, '\t')
+                   : string(style.tabCount, ' ');
             mLastStyleValue = mStyle.value;
+
+#if false // @@@ TODO
+
+            mArrayGap[0] = expand(style.gapA);
+            mArrayGap[1] = expand(style.gapB);
+            mArrayGap[2] = expand(style.gapB);
+
+            mObjectGap[0] = expand(style.gap1);
+            mObjectGap[1] = expand(style.gap2);
+            mObjectGap[2] = expand(style.gap3);
+            mObjectGap[3] = expand(style.gap4);
+            mObjectGap[4] = expand(style.gap5);
+            mObjectGap[5] = expand(style.gap6);
+            mObjectGap[6] = expand(style.gap7);
+
+            mEmptyArray = expand(style.emptyArray);
+            mEmptyObject = expand(style.emptyObject);
+
+#endif // false
+
         }
-    }
+    } // updateExpansions()
 }; // class JSONStyleHelper
 
 } // namespace internal
@@ -687,12 +733,14 @@ public:
         mDisableBras(false)
     {}
 
-    // Parses the format in the format {<indent>,<per-call-parms>,<style>,<format>}
+    //
+    // Generic parser for however many comma-separated arguments are provided,
+    // including support for nested arguments (requires call to
+    // Base::resolveArgs() in Base children's format()).
+    //
     template<typename ParseContext>
     constexpr auto parse(ParseContext& ctx)
     {
-        // generic handling of N comma-separated arguments, including recursive braces
-
         int parmIndex = 0;
         int braces = 1;
         auto it = ctx.begin();
@@ -724,17 +772,18 @@ public:
         }
 
         return it;
+
     } // parse()
 
-
-
+    //
     // This function must be called by each Base child immediately on
-    //  entry to the format() function. It completes the updating of the style
-    //  object based on arguments provided, if necessary.
+    // entry to the format() function. It completes the updating of the style
+    // object based on arguments provided, including nested, if necessary.
+    // Only the first four aguments are processed.
+    //
     template<typename FormatContext>
     void resolveArgs(FormatContext& ctx)
     {
-        using namespace std::string_literals;
         using fmt::format_to;
         using namespace fmtster::internal;
 
@@ -742,7 +791,9 @@ public:
         mArgData.resize(4, "");
         mNestedArgIndex.resize(4, 0);
 
-
+        //
+        // Resolve each argument
+        //
 
         //
         // format
@@ -800,7 +851,7 @@ public:
                 [](auto value) -> VALUE_T
                 {
                     // This construct is required because at compile time all
-                    //  type paths are linked, even though that are not allowed
+                    //  type paths are linked, even though they are not allowed
                     //  at run time, and without this, the return value doens't
                     //  match the function return value in some cases, so the
                     //  compile fails.
@@ -856,7 +907,7 @@ public:
                     }
                     else
                     {
-                        throw fmt::format_error(F("fmtster: unsupported nested argument type for per call parameters: (only strings accepted)",
+                        throw fmt::format_error(F("fmtster: unsupported nested argument type for per call parameters: {} (only strings accepted)",
                                                   typeid(value).name()));
                     }
                 },
@@ -884,7 +935,7 @@ public:
                     }
                     else
                     {
-                        throw fmt::format_error(F("fmtster: unsupported nested argument type for indent: (only integers accepted)",
+                        throw fmt::format_error(F("fmtster: unsupported nested argument type for indent: {} (only integers accepted)",
                                                   typeid(value).name()));
                     }
                 },
@@ -907,16 +958,17 @@ public:
 
         mpStyleHelper->updateExpansions();
 
-        // expand indenting
+        //
+        // Configure indentation
+        //
         mBraIndent.clear();
         for (auto i = mIndentSetting; i; --i)
-            mBraIndent += mpStyleHelper->tab;
-        mDataIndent = mBraIndent + mpStyleHelper->tab;
+            mBraIndent += mpStyleHelper->mTab;
+        mDataIndent = mBraIndent + mpStyleHelper->mTab;
 
-
-
-
-        // parse those parms
+        //
+        // Parse the per call parms
+        //
         bool negate = false;
         for (const auto c : pcpSetting)
         {
@@ -994,7 +1046,7 @@ struct fmt::formatter<T,
             bool isFirstElement = (itC == c.begin());
             bool newLine = !mDisableBras || !isFirstElement;
             if (newLine)
-                fmtStr = "\n";
+                fmtStr = mpStyleHelper->mNewline;
 
             // get current element value
             const auto& val = *itC;
@@ -1057,7 +1109,7 @@ struct fmt::formatter<T,
             bool isFirstElement = (itC == c.begin());
             bool newLine = !mDisableBras || !isFirstElement;
             if (newLine)
-                fmtStr = "\n";
+                fmtStr = mpStyleHelper->mNewline;
 
             // output the key
             const auto& key = itC->first;
@@ -1124,12 +1176,14 @@ struct fmt::formatter<T,
             {
                 // output closing brace
                 itFC = format_to(itFC,
-                                is_braceable_v<T> ? "\n{}}}" : "\n{}]",
+                                is_braceable_v<T> ? "{}{}}}" : "{}{}]",
+                                mpStyleHelper->mNewline,
                                 mBraIndent);
             }
         }
 
         return itFC;
+
     } // format()
 
 }; // struct fmt::formatter< containers >
@@ -1194,7 +1248,7 @@ struct fmt::formatter<std::pair<T1, T2> >
         // output opening bracket/brace (if enabled)
         if (!mDisableBras)
         {
-            itFC = format_to(itFC, "{{\n");
+            itFC = format_to(itFC, "{{{}", mpStyleHelper->mNewline);
             mIndentSetting++;
         }
 
@@ -1233,11 +1287,11 @@ struct fmt::formatter<std::pair<T1, T2> >
         // output closing bracket/brace (if enabled)
         if (!mDisableBras)
         {
-            itFC = format_to(itFC, "\n{}}}", mBraIndent);
+            itFC = format_to(itFC, "{}{}}}", mpStyleHelper->mNewline, mBraIndent);
         }
 
         return itFC;
-    }
+    } // format()
 }; // struct fmt::formatter<std::pair<> >
 
 //
@@ -1284,7 +1338,7 @@ struct fmt::formatter<std::tuple<Ts...> >
                 {
                     std::string fmtStr;
                     if (!mDisableBras || (count != sizeof...(Ts)))
-                        fmtStr = "\n";
+                        fmtStr = mpStyleHelper->mNewline;
 
                     if (fmtster::internal::is_fmtsterable_v<decltype(elem)>)
                     {
@@ -1317,12 +1371,12 @@ struct fmt::formatter<std::tuple<Ts...> >
             // output closing brace (if enabled)
             if (!mDisableBras)
             {
-                itFC = format_to(itFC, "\n{}}}", mBraIndent);
+                itFC = format_to(itFC, "{}{}}}", mpStyleHelper->mNewline, mBraIndent);
             }
         }
 
         return itFC;
-    }
+    } // format()
 }; // struct fmt::formatter<std::tuple<> >
 
 //
@@ -1335,7 +1389,6 @@ struct fmt::formatter<fmtster::JSONStyle>
     template<typename FormatContext>
     auto format(const fmtster::JSONStyle& style, FormatContext& ctx)
     {
-        using namespace std::string_literals;
         using std::make_pair;
 
         resolveArgs(ctx);
@@ -1343,30 +1396,31 @@ struct fmt::formatter<fmtster::JSONStyle>
         auto itFC = ctx.out();
 
         const auto tup = std::make_tuple(
-            make_pair("value"s, style.value),
-#if false // @@@ disable members that are not implemented
-            make_pair("cr"s, style.cr),
-            make_pair("lf"s, style.lf),
-#endif // false
-            make_pair("hardTab"s, style.hardTab),
-            make_pair("tabCount"s, style.tabCount)
-#if false // @@@ disable members that are not implemented
+            make_pair("value", style.value),
+            make_pair("cr", style.cr),
+            make_pair("lf", style.lf),
+            make_pair("hardTab", style.hardTab),
+            make_pair("tabCount", style.tabCount)
+
+#if false // @@@ TODO
             ,
-            make_pair("gapA"s, style.gapA),
-            make_pair("gapB"s, style.gapB),
-            make_pair("gapC"s, style.gapC),
-            make_pair("gap1"s, style.gap1),
-            make_pair("gap2"s, style.gap2),
-            make_pair("gap3"s, style.gap3),
-            make_pair("gap4"s, style.gap4),
-            make_pair("gap5"s, style.gap5),
-            make_pair("gap6"s, style.gap6),
-            make_pair("gap7"s, style.gap7),
-            make_pair("emptyArray"s, style.emptyArray),
-            make_pair("emptyObject"s, style.emptyObject),
-            make_pair("sva"s, style.sva),
-            make_pair("svo"s, style.svo)
+            make_pair("gapA", style.gapA),
+            make_pair("gapB", style.gapB),
+            make_pair("gapC", style.gapC),
+            make_pair("gap1", style.gap1),
+            make_pair("gap2", style.gap2),
+            make_pair("gap3", style.gap3),
+            make_pair("gap4", style.gap4),
+            make_pair("gap5", style.gap5),
+            make_pair("gap6", style.gap6),
+            make_pair("gap7", style.gap7),
+            make_pair("emptyArray", style.emptyArray),
+            make_pair("emptyObject", style.emptyObject),
+            make_pair("singleLineArray", style.singleLineArray),
+            make_pair("singleLineObject", style.singleLineObject)
+
 #endif // false
+
         );
         auto pcp = mDisableBras ? "-b" : "";
         itFC = fmt::format_to(itFC,
@@ -1378,7 +1432,7 @@ struct fmt::formatter<fmtster::JSONStyle>
                             mFormatSetting);
 
         return itFC;
-    }
+    } // format()
 };
 
 #undef JSONSTYLESTRUCT

--- a/fmtstertest.cpp
+++ b/fmtstertest.cpp
@@ -452,9 +452,9 @@ enable_if_t<is_adapter_v<C>,
     auto data = DATA; \
     string str = F("{}", data); \
 cout << str << endl; \
-    auto gRef = GetReference(data); \
+    const auto REF = GetReference(data); \
 /* cout << ref << endl; */ \
-    EXPECT_EQ(gRef, str) << F("ref: {}\nstr: {}", gRef, str); \
+    EXPECT_EQ(REF, str) << F("ref: {}\nstr: {}", REF, str); \
 }
 
 #define ARRAYCONTAINERTEST(TYPE) \
@@ -560,49 +560,78 @@ std::string ReplaceString(std::string subject,
     return subject;
 }
 
-// initial default style
-static string gRef =
-    "{\n"
-    "  \"value\" : 4,\n"
-#if false // @@@ disable members that are not implemented
-    "  \"cr\" : false,\n"
-    "  \"lf\" : true,\n"
+string RefDump(const fmtster::JSONStyle& style, string tab = "style")
+{
+    if (tab == "style")
+        tab = style.hardTab
+              ? string(style.tabCount, '\t')
+              : string(style.tabCount, ' ');
+    return
+        F("{{\n"
+          "{}\"value\" : {},\n"
+          "{}\"cr\" : {},\n"
+          "{}\"lf\" : {},\n"
+          "{}\"hardTab\" : {},\n"
+          "{}\"tabCount\" : {}"
+                             "\n"
+#if false
+                             ",\n"
+          "{}\"gapA\" : {},\n"
+          "{}\"gapB\" : {},\n"
+          "{}\"gapC\" : {},\n"
+          "{}\"gap1\" : {},\n"
+          "{}\"gap2\" : {},\n"
+          "{}\"gap3\" : {},\n"
+          "{}\"gap4\" : {},\n"
+          "{}\"gap5\" : {},\n"
+          "{}\"gap6\" : {},\n"
+          "{}\"gap7\" : {},\n"
+          "{}\"emptyArray\" : {},\n"
+          "{}\"emptyObject\" : {},\n"
+          "{}\"singleLineArray\" : {},\n"
+          "{}\"singleLineObject\" : {}\n"
 #endif // false
-    "  \"hardTab\" : false,\n"
-    "  \"tabCount\" : 2"
-#if false // @@@ disable members that are not implemented
-                      ",\n"
-    "  \"gapA\" : 14,\n"
-    "  \"gapB\" : 2,\n"
-    "  \"gapC\" : 2,\n"
-    "  \"gap1\" : 14,\n"
-    "  \"gap2\" : 0,\n"
-    "  \"gap3\" : 2,\n"
-    "  \"gap4\" : 14,\n"
-    "  \"gap5\" : 0,\n"
-    "  \"gap6\" : 2,\n"
-    "  \"gap7\" : 8,\n"
-    "  \"emptyArray\" : 2,\n"
-    "  \"emptyObject\" : 2,\n"
-    "  \"sva\" : 1,\n"
-    "  \"svo\" : 1"
+          "}}",
+      tab, style.value,
+      tab, style.cr,
+      tab, style.lf,
+      tab, style.hardTab,
+      tab, style.tabCount
+#if false
+      ,
+      tab, style.gapA,
+      tab, style.gapB,
+      tab, style.gapC,
+      tab, style.gap1,
+      tab, style.gap2,
+      tab, style.gap3,
+      tab, style.gap4,
+      tab, style.gap5,
+      tab, style.gap6,
+      tab, style.gap7,
+      tab, style.emptyArray,
+      tab, style.emptyObject,
+      tab, style.singleLineArray,
+      tab, style.singleLineObject
 #endif // false
-                 "\n"
-    "}";
+      );
+}
 
 TEST_F(FmtsterTest, JSONStyle_StructDefaultDump)
 {
     fmtster::JSONStyle style;
     string str;
     str = F("{}", style);
-    ASSERT_EQ(gRef, str) << F("ref JSONStyle: {},\ninitial default JSONStyle: {}", gRef, str);
+    const auto REF = RefDump(style);
+    ASSERT_EQ(REF, str) << F("ref JSONStyle: {},\ninitial default JSONStyle: {}", REF, str);
 }
 
 TEST_F(FmtsterTest, JSONStyle_InitialDefaultDump)
 {
     // current default should match initial default
     auto str = F("{}", fmtster::Base::GetDefaultJSONStyle());
-    ASSERT_EQ(gRef, str) << F("ref JSONStyle: {},\ncurrent default str: {}", gRef, str);
+    const auto REF = RefDump(fmtster::Base::GetDefaultJSONStyle());
+    ASSERT_EQ(REF, str) << F("ref JSONStyle: {},\ncurrent default str: {}", REF, str);
 }
 
 TEST_F(FmtsterTest, JSONStyle_HardTabDump)
@@ -611,12 +640,9 @@ TEST_F(FmtsterTest, JSONStyle_HardTabDump)
     fmtster::JSONStyle style;
     style.hardTab = true;
     style.tabCount = 1;
-    // change reference string to change values (style still default)
-    gRef = ReplaceString(gRef, "\"value\" : 4", "\"value\" : 3");
-    gRef = ReplaceString(gRef, "\"hardTab\" : false", "\"hardTab\" : true");
-    gRef = ReplaceString(gRef, "\"tabCount\" : 2", "\"tabCount\" : 1");
     auto str = F("{}", style);
-    ASSERT_EQ(gRef, str) << F("ref JSONStyle: {},\ncurrent default str: {}", gRef, str);
+    const auto REF = RefDump(style, "  ");
+    ASSERT_EQ(REF, str) << F("ref JSONStyle: {},\ncurrent default str: {}", REF, str);
 }
 
 TEST_F(FmtsterTest, JSONStyle_HardTabDump_HardTabStruct)
@@ -624,10 +650,9 @@ TEST_F(FmtsterTest, JSONStyle_HardTabDump_HardTabStruct)
     fmtster::JSONStyle style;
     style.hardTab = true;
     style.tabCount = 1;
-    // change reference string to use hard tabs in style
-    gRef = ReplaceString(gRef, "  ", "\t");
     auto str = F("{:,,{},j}", style, style.value);
-    ASSERT_EQ(gRef, str) << F("ref JSONStyle: {},\ncurrent default str: {}", gRef, str);
+    const auto REF = RefDump(style);
+    ASSERT_EQ(REF, str) << F("ref JSONStyle: {},\ncurrent default str: {}", REF, str);
 }
 
 TEST_F(FmtsterTest, JSONStyle_HardTabDefault)
@@ -644,14 +669,16 @@ TEST_F(FmtsterTest, JSONStyle_HardTabDefaultDump)
 {
     // serialize current default (with current default style) & compare to reference
     auto str = F("{}", fmtster::Base::GetDefaultJSONStyle());
-    ASSERT_EQ(gRef, str) << F("ref JSONStyle: {},\ncurrent default str: {}", gRef, str);
+    const auto REF = RefDump(fmtster::Base::GetDefaultJSONStyle());
+    ASSERT_EQ(REF, str) << F("ref JSONStyle: {},\ncurrent default str: {}", REF, str);
 }
 
 TEST_F(FmtsterTest, JSONStyle_RestoreDefaultToStructDefault)
 {
     // return current default to initial default for following tests
     auto str = F("{:,s,{},j}", make_tuple(), fmtster::JSONStyle{}.value);
-    ASSERT_EQ(fmtster::JSONStyle{}.value, fmtster::Base::GetDefaultJSONStyle().value) << F("current default JSONStyle: {},\ninitial default str: {}", gRef, str);
+    const auto REF = RefDump(fmtster::JSONStyle{});
+    ASSERT_EQ(fmtster::JSONStyle{}.value, fmtster::Base::GetDefaultJSONStyle().value) << F("current default JSONStyle: {},\ninitial default str: {}", REF, str);
 }
 
 TEST_F(FmtsterTest, JSONStyle_Style_0)
@@ -929,22 +956,22 @@ cout << str << endl;
 TEST_F(FmtsterTest, pairs)
 {
     string ref = "{\n  \"foo\" : \"bar\"\n}, {\n  \"foobar\" : 7\n}";
-    string str = F("{}, {}", make_pair("foo"s, "bar"s), make_pair("foobar"s, 7));
+    string str = F("{}, {}", make_pair("foo", "bar"), make_pair("foobar", 7));
 cout << "ONE:\n" << str << endl;
     EXPECT_EQ(ref, str);
 
     ref = "\"foo\" : \"bar\", \"foobar\" : 7";
-    str = F("{:,-b}, {:,-b}", make_pair("foo"s, "bar"s), make_pair("foobar"s, 7));
+    str = F("{:,-b}, {:,-b}", make_pair("foo", "bar"), make_pair("foobar", 7));
 cout << "TWO:\n" << str << endl;
     EXPECT_EQ(ref, str);
 
     ref = "{\n    \"foo\" : \"bar\"\n  }, {\n    \"foobar\" : 7\n  }";
-    str = F("{:1}, {:1}", make_pair("foo"s, "bar"s), make_pair("foobar"s, 7));
+    str = F("{:1}, {:1}", make_pair("foo", "bar"), make_pair("foobar", 7));
 cout << "THREE:\n" << str << endl;
     EXPECT_EQ(ref, str);
 
     ref = "  \"foo\" : \"bar\", \"foobar\" : 7";
-    str = F("{:1,-b}, {:,-b}", make_pair("foo"s, "bar"s), make_pair("foobar"s, 7));
+    str = F("{:1,-b}, {:,-b}", make_pair("foo", "bar"), make_pair("foobar", 7));
 cout << "FOUR:\n" << str << endl;
     EXPECT_EQ(ref, str);
 }
@@ -954,7 +981,7 @@ TEST_F(FmtsterTest, custom_indent_pairs)
     const string ref = "    \"fu\" : \"baz\", \"fubar\" : 3.14";
     fmtster::JSONStyle style;
     style.tabCount = 4;
-    string str = F("{:1,-b,{},j}, {:,-b}", make_pair("fu"s, "baz"s), style.value, make_pair("fubar"s, 3.14));
+    string str = F("{:1,-b,{},j}, {:,-b}", make_pair("fu", "baz"), style.value, make_pair("fubar", 3.14));
 cout << str << endl;
     EXPECT_EQ(ref, str);
 }
@@ -967,7 +994,7 @@ TEST_F(FmtsterTest, NestedPairs)
         "}";
     fmtster::JSONStyle style;
     style.tabCount = 4;
-    string str = F("{:,-b,{},j}", make_pair("foo"s, make_pair("bar"s, "baz"s)), style.value);
+    string str = F("{:,-b,{},j}", make_pair("foo", make_pair("bar", "baz")), style.value);
 cout << str << endl;
     EXPECT_EQ(ref, str);
 
@@ -975,7 +1002,7 @@ cout << str << endl;
         "    \"foo\" : {\n"
         "        \"bar\" : \"baz\"\n"
         "    }";
-    str = F("{:1,-b,{},j}", make_pair("foo"s, make_pair("bar"s, "baz"s)), style.value);
+    str = F("{:1,-b,{},j}", make_pair("foo", make_pair("bar", "baz")), style.value);
 cout << str << endl;
     EXPECT_EQ(ref, str);
 
@@ -1010,7 +1037,7 @@ cout << str << endl;
         "        ]\n"
         "    }\n"
         "}";
-    str = F("{:,-b,{},j}", make_pair("foo"s, make_pair("bar"s, mapofvectorofstrings)), style.value);
+    str = F("{:,-b,{},j}", make_pair("foo", make_pair("bar", mapofvectorofstrings)), style.value);
 cout << str << endl;
     EXPECT_EQ(ref, str);
 
@@ -1027,7 +1054,7 @@ cout << str << endl;
     "            ]\n"
     "        }\n"
     "    }";
-    str = F("{:1,-b,{},j}", make_pair("foo"s, make_pair("bar"s, mapofvectorofstrings)), style.value);
+    str = F("{:1,-b,{},j}", make_pair("foo", make_pair("bar", mapofvectorofstrings)), style.value);
 cout << str << endl;
     EXPECT_EQ(ref, str);
 }
@@ -1078,11 +1105,11 @@ cout << str << endl;
 TEST_F(FmtsterTest, Tuple)
 {
     const auto tup = make_tuple(
-        make_pair("int"s, 25),
-        make_pair("string"s, "Hello"s),
-        make_pair("float"s, 9.31f),
-        make_pair("vector"s, vector<int>{3, 1, 4}),
-        make_pair("boolean"s, true));
+        make_pair("int", 25),
+        make_pair("string", "Hello"),
+        make_pair("float", 9.31f),
+        make_pair("vector", vector<int>{3, 1, 4}),
+        make_pair("boolean", true));
     fmtster::JSONStyle style;
     style.tabCount = 4;
    string str = F("{:1,-b,{},j}", tup, style.value);
@@ -1121,38 +1148,38 @@ TEST_F(FmtsterTest, Layers)
 //     F("{}", fmtster::JSONStyle{});
 
     // pair
-    auto pr = make_pair("key"s, "value"s);
+    auto pr = make_pair("key", "value");
     string str = F("{}", pr);
-    EXPECT_EQ("{\n  \"key\" : \"value\"\n}"s, str);
+    EXPECT_EQ("{\n  \"key\" : \"value\"\n}", str);
     str = F("{:,-b}", pr);
-    EXPECT_EQ("\"key\" : \"value\""s, str);
+    EXPECT_EQ("\"key\" : \"value\"", str);
     str = F("{:1}", pr);
-    EXPECT_EQ("{\n    \"key\" : \"value\"\n  }"s, str);
+    EXPECT_EQ("{\n    \"key\" : \"value\"\n  }", str);
     str = F("{:1,-b}", pr);
-    EXPECT_EQ("  \"key\" : \"value\""s, str);
+    EXPECT_EQ("  \"key\" : \"value\"", str);
     // tuple
-    auto tup = make_tuple("string"s, 1, true, 3.14);
+    auto tup = make_tuple("string", 1, true, 3.14);
     str = F("{}", tup);
-    EXPECT_EQ("{\n  \"string\",\n  1,\n  true,\n  3.14\n}"s, str);
+    EXPECT_EQ("{\n  \"string\",\n  1,\n  true,\n  3.14\n}", str);
     str = F("{:,-b}", tup);
-    EXPECT_EQ("\"string\",\n1,\ntrue,\n3.14"s, str);
+    EXPECT_EQ("\"string\",\n1,\ntrue,\n3.14", str);
     str = F("{:1}", tup);
-    EXPECT_EQ("{\n    \"string\",\n    1,\n    true,\n    3.14\n  }"s, str);
+    EXPECT_EQ("{\n    \"string\",\n    1,\n    true,\n    3.14\n  }", str);
     str = F("{:1,-b}", tup);
-    EXPECT_EQ("  \"string\",\n  1,\n  true,\n  3.14"s, str);
-    auto mm2 = multimap<string, map<string, int> >{ { "mm1"s, { { "one"s, 1 }, { "two"s, 2 }, { "three"s, 3 } } },
-                                                    { "mm2"s, { { "four"s, 4 }, { "five"s, 5 } } },
-                                                    { "mm1"s, { { "six"s, 6 }, { "seven"s, 7 } } } };
+    EXPECT_EQ("  \"string\",\n  1,\n  true,\n  3.14", str);
+    auto mm2 = multimap<string, map<string, int> >{ { "mm1", { { "one", 1 }, { "two", 2 }, { "three", 3 } } },
+                                                    { "mm2", { { "four", 4 }, { "five", 5 } } },
+                                                    { "mm1", { { "six", 6 }, { "seven", 7 } } } };
     str = F("{}", mm2);
-    EXPECT_EQ("{\n  \"mm1\" : [\n    {\n      \"seven\" : 7,\n      \"six\" : 6\n    },\n    {\n      \"one\" : 1,\n      \"three\" : 3,\n      \"two\" : 2\n    }\n  ],\n  \"mm2\" : [\n    {\n      \"five\" : 5,\n      \"four\" : 4\n    }\n  ]\n}"s,
+    EXPECT_EQ("{\n  \"mm1\" : [\n    {\n      \"seven\" : 7,\n      \"six\" : 6\n    },\n    {\n      \"one\" : 1,\n      \"three\" : 3,\n      \"two\" : 2\n    }\n  ],\n  \"mm2\" : [\n    {\n      \"five\" : 5,\n      \"four\" : 4\n    }\n  ]\n}",
               str);
     str = F("{:,-b}", mm2);
-    EXPECT_EQ("\"mm1\" : [\n  {\n    \"seven\" : 7,\n    \"six\" : 6\n  },\n  {\n    \"one\" : 1,\n    \"three\" : 3,\n    \"two\" : 2\n  }\n],\n\"mm2\" : [\n  {\n    \"five\" : 5,\n    \"four\" : 4\n  }\n]"s,
+    EXPECT_EQ("\"mm1\" : [\n  {\n    \"seven\" : 7,\n    \"six\" : 6\n  },\n  {\n    \"one\" : 1,\n    \"three\" : 3,\n    \"two\" : 2\n  }\n],\n\"mm2\" : [\n  {\n    \"five\" : 5,\n    \"four\" : 4\n  }\n]",
               str);
     str = F("{:1}", mm2);
-    EXPECT_EQ("{\n    \"mm1\" : [\n      {\n        \"seven\" : 7,\n        \"six\" : 6\n      },\n      {\n        \"one\" : 1,\n        \"three\" : 3,\n        \"two\" : 2\n      }\n    ],\n    \"mm2\" : [\n      {\n        \"five\" : 5,\n        \"four\" : 4\n      }\n    ]\n  }"s,
+    EXPECT_EQ("{\n    \"mm1\" : [\n      {\n        \"seven\" : 7,\n        \"six\" : 6\n      },\n      {\n        \"one\" : 1,\n        \"three\" : 3,\n        \"two\" : 2\n      }\n    ],\n    \"mm2\" : [\n      {\n        \"five\" : 5,\n        \"four\" : 4\n      }\n    ]\n  }",
               str);
     str = F("{:1,-b}", mm2);
-    EXPECT_EQ("  \"mm1\" : [\n    {\n      \"seven\" : 7,\n      \"six\" : 6\n    },\n    {\n      \"one\" : 1,\n      \"three\" : 3,\n      \"two\" : 2\n    }\n  ],\n  \"mm2\" : [\n    {\n      \"five\" : 5,\n      \"four\" : 4\n    }\n  ]"s,
+    EXPECT_EQ("  \"mm1\" : [\n    {\n      \"seven\" : 7,\n      \"six\" : 6\n    },\n    {\n      \"one\" : 1,\n      \"three\" : 3,\n      \"two\" : 2\n    }\n  ],\n  \"mm2\" : [\n    {\n      \"five\" : 5,\n      \"four\" : 4\n    }\n  ]",
               str);
 }


### PR DESCRIPTION
* Added system-based newline support (can be overridden by client)
* Fixed exception strings which were missing type arguments
* Added benchmarking to example-json (used to compare this design to the LRU design in enhancement/19-lru branch)
* Enabled -O3 optimization (for benchmarking) in Makefile
* Restored stripping of executables in Makefile
* Finished removing all `string_literals`, which are no longer necessary with the addition of `char*` support
* Renamed some internal members
* Misc. comments mods & additions
* Bump version to 0.5.1